### PR TITLE
Attempt to upgrade to passkit-generator v3.1.0

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
     "cors": "^2.8.5",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.1.0",
-    "passkit-generator": "^3.0.1"
+    "passkit-generator": "^3.1.0"
   },
   "devDependencies": {
     "tslint": "^5.12.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
     "cors": "^2.8.5",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.1.0",
-    "passkit-generator": "^1.6.7"
+    "passkit-generator": "^3.0.1"
   },
   "devDependencies": {
     "tslint": "^5.12.0",


### PR DESCRIPTION
Hey there @neogucky, hope to find you well!
Recently I've released passkit-generator v3.1.0 and deprecated older versions, as they are not supported anymore. So, I'm opening a few PRs in open source projects that use passkit-generator to prompt them in upgrading.

So, here I am. I've applied a few changes to the firebase cloud function file, but, of course, I wasn't able to test it.

I've also upgraded `package.json`, but omitted `package-lock.json`, as an upgrade of it would have brought it to its v2. Since I say the minimum supported node version is 8 (which is quite old, actually - LTS is right now v14), I preferred to not commit it.

For the same reason as above, I've also used `promisify` with `fs.readFile` to read the certificates. This is because I'd rather have used `fs.promises`, but they are available since Node v10.

Also, reading the certificates is not the best thing: you might think of putting them in the `process.env`. Here is the link to the article for firebase: https://firebase.google.com/docs/functions/config-env.

Hope this is appreciated. Of course, I'm opening this as a draft, so you are free to review it, test it and mark it as complete and merge it once you are done. I've also flagged "Allow edits by maintainers", so you can directly push things in my fork.

Have a nice day.
Alexander